### PR TITLE
Adopt centralized localization for user-facing strings

### DIFF
--- a/OracleLightApp/Generated/Strings.swift
+++ b/OracleLightApp/Generated/Strings.swift
@@ -14,6 +14,11 @@ internal enum L10n {
     internal static let moodJoyful = NSLocalizedString("mood.joyful", comment: "Joyful mood")
     internal static let moodEcstatic = NSLocalizedString("mood.ecstatic", comment: "Ecstatic mood")
 
+    // Palette names
+    internal static let paletteVivid = NSLocalizedString("palette.vivid", comment: "Vivid palette")
+    internal static let palettePastel = NSLocalizedString("palette.pastel", comment: "Pastel palette")
+    internal static let paletteDark = NSLocalizedString("palette.dark", comment: "Dark palette")
+
     // Notifications
     internal static let notificationPraiseTitle = NSLocalizedString("notification.praise.title", comment: "Praise rule title")
     internal static let notificationPraiseBody = NSLocalizedString("notification.praise.body", comment: "Praise rule body")
@@ -40,6 +45,7 @@ internal enum L10n {
     internal static let homeTabDaily = NSLocalizedString("home.tab.daily", comment: "Daily")
     internal static let homeTabWeekly = NSLocalizedString("home.tab.weekly", comment: "Weekly")
     internal static let homeTabMonthly = NSLocalizedString("home.tab.monthly", comment: "Monthly")
+    internal static let homeTitle = NSLocalizedString("home.title", comment: "Home title")
 
     // Charts
     internal static let chartYAxisMood = NSLocalizedString("chart.yaxis.mood", comment: "Mood axis")

--- a/OracleLightApp/Resources/de.lproj/Localizable.strings
+++ b/OracleLightApp/Resources/de.lproj/Localizable.strings
@@ -7,6 +7,11 @@
 "mood.joyful" = "Freudig";
 "mood.ecstatic" = "Ekstatisch";
 
+/* Palettennamen */
+"palette.vivid" = "Kräftig";
+"palette.pastel" = "Pastell";
+"palette.dark" = "Dunkel";
+
 /* Benachrichtigungen */
 "notification.praise.title" = "Großartige Arbeit!";
 "notification.praise.body" = "Du fühlst dich in letzter Zeit großartig. Mach weiter so!";
@@ -31,6 +36,7 @@
 "home.tab.daily" = "Täglich";
 "home.tab.weekly" = "Wöchentlich";
 "home.tab.monthly" = "Monatlich";
+"home.title" = "OracleLight";
 
 /* Diagramme */
 "chart.yaxis.mood" = "Stimmung";

--- a/OracleLightApp/Resources/en.lproj/Localizable.strings
+++ b/OracleLightApp/Resources/en.lproj/Localizable.strings
@@ -7,6 +7,11 @@
 "mood.joyful" = "Joyful";
 "mood.ecstatic" = "Ecstatic";
 
+/* Palette names */
+"palette.vivid" = "Vivid";
+"palette.pastel" = "Pastel";
+"palette.dark" = "Dark";
+
 /* Notifications */
 "notification.praise.title" = "Great job!";
 "notification.praise.body" = "You've been feeling great lately. Keep it up!";
@@ -31,6 +36,7 @@
 "home.tab.daily" = "Daily";
 "home.tab.weekly" = "Weekly";
 "home.tab.monthly" = "Monthly";
+"home.title" = "OracleLight";
 
 /* Charts */
 "chart.yaxis.mood" = "Mood";

--- a/OracleLightApp/Views/Home/HomeView.swift
+++ b/OracleLightApp/Views/Home/HomeView.swift
@@ -18,13 +18,13 @@ struct HomeView: View {
         NavigationStack {
             TabView(selection: $selection) {
                 DailyChartView(entries: moodStore.entries)
-                    .tabItem { Label(NSLocalizedString("home.tab.daily", comment: "Daily"), systemImage: "chart.bar.fill") }
+                    .tabItem { Label(L10n.homeTabDaily, systemImage: "chart.bar.fill") }
                     .tag(Tab.daily)
                 WeeklyChartView(entries: moodStore.entries)
-                    .tabItem { Label(NSLocalizedString("home.tab.weekly", comment: "Weekly"), systemImage: "calendar") }
+                    .tabItem { Label(L10n.homeTabWeekly, systemImage: "calendar") }
                     .tag(Tab.weekly)
                 MonthlyChartView(entries: moodStore.entries)
-                    .tabItem { Label(NSLocalizedString("home.tab.monthly", comment: "Monthly"), systemImage: "calendar.circle") }
+                    .tabItem { Label(L10n.homeTabMonthly, systemImage: "calendar.circle") }
                     .tag(Tab.monthly)
             }
             .onAppear {
@@ -32,7 +32,7 @@ struct HomeView: View {
                     self.ruleEvents = (try? await DatabaseService.shared.fetchRuleEvents()) ?? []
                 }
             }
-            .navigationTitle("OracleLight")
+            .navigationTitle(L10n.homeTitle)
             .toolbar {
                 NavigationLink(destination: SettingsView()) {
                     Image(systemName: "gearshape")
@@ -51,14 +51,14 @@ struct DailyChartView: View {
         Chart {
             ForEach(todayEntries) { entry in
                 BarMark(
-                    x: .value("Time", entry.timestamp, unit: .hour),
-                    y: .value("Mood", entry.mood.rawValue)
+                    x: .value(L10n.chartXAxisTime, entry.timestamp, unit: .hour),
+                    y: .value(L10n.chartYAxisMood, entry.mood.rawValue)
                 )
-                .foregroundStyle(by: .value("Mood", entry.mood.localizedDescription))
+                .foregroundStyle(by: .value(L10n.chartYAxisMood, entry.mood.localizedDescription))
             }
         }
-        .chartYAxisLabel(NSLocalizedString("chart.yaxis.mood", comment: "Mood axis"))
-        .chartXAxisLabel(NSLocalizedString("chart.xaxis.time", comment: "Time axis"))
+        .chartYAxisLabel(L10n.chartYAxisMood)
+        .chartXAxisLabel(L10n.chartXAxisTime)
     }
 }
 
@@ -79,14 +79,14 @@ struct WeeklyChartView: View {
         Chart {
             ForEach(points, id: \ .0) { point in
                 RectangleMark(
-                    x: .value("Day", point.0),
-                    y: .value("Hour", point.1),
-                    color: .value("Mood", point.2)
+                    x: .value(L10n.chartXAxisDayOfWeek, point.0),
+                    y: .value(L10n.chartYAxisHour, point.1),
+                    color: .value(L10n.chartYAxisMood, point.2)
                 )
             }
         }
-        .chartXAxisLabel(NSLocalizedString("chart.xaxis.dayofweek", comment: "Day of week axis"))
-        .chartYAxisLabel(NSLocalizedString("chart.yaxis.hour", comment: "Hour axis"))
+        .chartXAxisLabel(L10n.chartXAxisDayOfWeek)
+        .chartYAxisLabel(L10n.chartYAxisHour)
     }
 }
 
@@ -106,13 +106,13 @@ struct MonthlyChartView: View {
         Chart {
             ForEach(points, id: \ .0) { point in
                 RectangleMark(
-                    x: .value("Day", point.0),
-                    y: .value("Hour", point.1),
-                    color: .value("Mood", point.2)
+                    x: .value(L10n.chartXAxisDay, point.0),
+                    y: .value(L10n.chartYAxisHour, point.1),
+                    color: .value(L10n.chartYAxisMood, point.2)
                 )
             }
         }
-        .chartXAxisLabel(NSLocalizedString("chart.xaxis.day", comment: "Day axis"))
-        .chartYAxisLabel(NSLocalizedString("chart.yaxis.hour", comment: "Hour axis"))
+        .chartXAxisLabel(L10n.chartXAxisDay)
+        .chartYAxisLabel(L10n.chartYAxisHour)
     }
 }

--- a/OracleLightApp/Views/Onboarding/OnboardingFlowView.swift
+++ b/OracleLightApp/Views/Onboarding/OnboardingFlowView.swift
@@ -55,15 +55,15 @@ struct PrivacyOathView: View {
     let onContinue: () -> Void
     var body: some View {
         VStack(spacing: 20) {
-            Text(NSLocalizedString("onboarding.privacy.title", comment: "Privacy oath title"))
+            Text(L10n.onboardingPrivacyTitle)
                 .font(.largeTitle)
                 .bold()
                 .multilineTextAlignment(.center)
-            Text(NSLocalizedString("onboarding.privacy.body", comment: "Privacy oath body"))
+            Text(L10n.onboardingPrivacyBody)
                 .multilineTextAlignment(.leading)
             Spacer()
             Button(action: onContinue) {
-                Text(NSLocalizedString("general.continue", comment: "Continue button"))
+                Text(L10n.generalContinue)
                     .padding()
                     .frame(maxWidth: .infinity)
                     .background(Color.accentColor)
@@ -83,7 +83,7 @@ struct PromptSchedulerEditView: View {
 
     var body: some View {
         VStack {
-            Text(NSLocalizedString("onboarding.prompts.title", comment: "Prompt schedule title"))
+            Text(L10n.onboardingPromptsTitle)
                 .font(.title2)
                 .padding(.top)
             List {
@@ -110,11 +110,11 @@ struct PromptSchedulerEditView: View {
             }
             .listStyle(.plain)
             Stepper(value: $settings.minimumIntervalMinutes, in: 30...120, step: 15) {
-                Text(String(format: NSLocalizedString("onboarding.prompts.interval", comment: "Minimum interval"), settings.minimumIntervalMinutes))
+                Text(L10n.onboardingPromptsInterval(settings.minimumIntervalMinutes))
             }
             .padding()
             Button(action: onContinue) {
-                Text(NSLocalizedString("general.continue", comment: "Continue button"))
+                Text(L10n.generalContinue)
                     .padding()
                     .frame(maxWidth: .infinity)
                     .background(Color.accentColor)
@@ -146,26 +146,26 @@ struct PaletteSelectionView: View {
     let onFinish: () -> Void
     var body: some View {
         VStack {
-            Text(NSLocalizedString("onboarding.palette.title", comment: "Palette selection title"))
+            Text(L10n.onboardingPaletteTitle)
                 .font(.title2)
                 .padding()
             HStack(spacing: 20) {
                 ForEach(Palette.allCases) { palette in
                     Button(action: { selected = palette }) {
-                        Text(palette.rawValue.capitalized)
+                        Text(palette.localizedName)
                             .padding()
                             .frame(maxWidth: .infinity)
                             .background(selected == palette ? Color.accentColor : Color.secondary.opacity(0.2))
                             .foregroundColor(selected == palette ? .white : .primary)
                             .cornerRadius(8)
                     }
-                    .accessibilityLabel(Text(palette.rawValue.capitalized))
+                    .accessibilityLabel(Text(palette.localizedName))
                 }
             }
             .padding()
             Spacer()
             Button(action: onFinish) {
-                Text(NSLocalizedString("onboarding.finish", comment: "Finish button"))
+                Text(L10n.onboardingFinish)
                     .padding()
                     .frame(maxWidth: .infinity)
                     .background(Color.accentColor)
@@ -173,6 +173,16 @@ struct PaletteSelectionView: View {
                     .cornerRadius(8)
             }
             .padding()
+        }
+    }
+}
+
+extension Palette {
+    var localizedName: String {
+        switch self {
+        case .vivid: return L10n.paletteVivid
+        case .pastel: return L10n.palettePastel
+        case .dark: return L10n.paletteDark
         }
     }
 }

--- a/OracleLightApp/Views/Settings/SettingsView.swift
+++ b/OracleLightApp/Views/Settings/SettingsView.swift
@@ -12,7 +12,7 @@ struct SettingsView: View {
 
     var body: some View {
         Form {
-            Section(header: Text(NSLocalizedString("settings.prompts.section", comment: "Prompt settings section"))) {
+            Section(header: Text(L10n.settingsPromptsSection)) {
                 ForEach(settings.promptTimes, id: \ .self) { time in
                     Text(time)
                 }
@@ -20,52 +20,52 @@ struct SettingsView: View {
                     settings.promptTimes.remove(atOffsets: offsets)
                 }
                 Button(action: addTime) {
-                    Label(NSLocalizedString("settings.prompts.add", comment: "Add prompt time"), systemImage: "plus")
+                    Label(L10n.settingsPromptsAdd, systemImage: "plus")
                 }
                 Stepper(value: $settings.minimumIntervalMinutes, in: 30...120, step: 15) {
-                    Text(String(format: NSLocalizedString("settings.prompts.interval", comment: "Minimum interval label"), settings.minimumIntervalMinutes))
+                    Text(L10n.settingsPromptsInterval(settings.minimumIntervalMinutes))
                 }
             }
-            Section(header: Text(NSLocalizedString("settings.palette.section", comment: "Palette section"))) {
-                Picker(NSLocalizedString("settings.palette.label", comment: "Palette picker label"), selection: $settings.palette) {
+            Section(header: Text(L10n.settingsPaletteSection)) {
+                Picker(L10n.settingsPaletteLabel, selection: $settings.palette) {
                     ForEach(Palette.allCases) { palette in
-                        Text(palette.rawValue.capitalized).tag(palette)
+                        Text(palette.localizedName).tag(palette)
                     }
                 }
                 .pickerStyle(SegmentedPickerStyle())
             }
-            Section(header: Text(NSLocalizedString("settings.export.section", comment: "Export section"))) {
+            Section(header: Text(L10n.settingsExportSection)) {
                 Button(action: { isPresentingExporter = true }) {
-                    Label(NSLocalizedString("settings.export.button", comment: "Export DB"), systemImage: "square.and.arrow.up")
+                    Label(L10n.settingsExportButton, systemImage: "square.and.arrow.up")
                 }
                 // Lock export behind the purchase. Users without the pro
                 // entitlement will see the button disabled.
                 .disabled(!purchaseController.isPurchased)
             }
-            Section(header: Text(NSLocalizedString("settings.legal.section", comment: "Legal section"))) {
+            Section(header: Text(L10n.settingsLegalSection)) {
                 NavigationLink(destination: LicensesView()) {
-                    Text(NSLocalizedString("settings.licenses", comment: "Licences"))
+                    Text(L10n.settingsLicenses)
                 }
                 NavigationLink(destination: LegalView()) {
-                    Text(NSLocalizedString("settings.legal", comment: "Legal"))
+                    Text(L10n.settingsLegal)
                 }
             }
-            Section(header: Text(NSLocalizedString("settings.purchase.section", comment: "Purchase section"))) {
+            Section(header: Text(L10n.settingsPurchaseSection)) {
                 if purchaseController.isPurchased {
-                    Text(NSLocalizedString("settings.purchase.thanks", comment: "Thank you text"))
+                    Text(L10n.settingsPurchaseThanks)
                 } else {
                     Button(action: {
                         Task { await purchaseController.purchase() }
                     }) {
-                        Text(String(format: NSLocalizedString("settings.purchase.price", comment: "Purchase price"), purchaseController.product?.displayPrice ?? "€7.99"))
+                        Text(L10n.settingsPurchasePrice(purchaseController.product?.displayPrice ?? "€7.99"))
                     }
                 }
             }
         }
-        .navigationTitle(NSLocalizedString("settings.title", comment: "Settings title"))
+        .navigationTitle(L10n.settingsTitle)
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
-                Button(NSLocalizedString("general.done", comment: "Done button"), action: save)
+                Button(L10n.generalDone, action: save)
             }
         }
         .onAppear {
@@ -129,10 +129,10 @@ struct DBExportDocument: FileDocument {
 struct LegalView: View {
     var body: some View {
         ScrollView {
-            Text(NSLocalizedString("legal.content", comment: "Legal content"))
+            Text(L10n.legalContent)
                 .padding()
         }
-        .navigationTitle(NSLocalizedString("settings.legal", comment: "Legal"))
+        .navigationTitle(L10n.settingsLegal)
     }
 }
 
@@ -141,8 +141,8 @@ struct LegalView: View {
 struct LicensesView: View {
     var body: some View {
         List {
-            Text(NSLocalizedString("licenses.content", comment: "Licences content"))
+            Text(L10n.licensesContent)
         }
-        .navigationTitle(NSLocalizedString("settings.licenses", comment: "Licences"))
+        .navigationTitle(L10n.settingsLicenses)
     }
 }

--- a/scripts/generate_strings.sh
+++ b/scripts/generate_strings.sh
@@ -11,3 +11,4 @@ set -euo pipefail
 project_root=$(dirname "$0")/..
 
 swiftgen config run --config "$project_root/swiftgen.yml"
+

--- a/swiftgen.yml
+++ b/swiftgen.yml
@@ -1,9 +1,10 @@
 strings:
   inputs:
-    - OracleLightApp/Resources/en.lproj
-    - OracleLightApp/Resources/de.lproj
+    - OracleLightApp/Resources/en.lproj/Localizable.strings
+    - OracleLightApp/Resources/de.lproj/Localizable.strings
   outputs:
     - templateName: structured-swift5
       output: OracleLightApp/Generated/Strings.swift
       params:
         enumName: L10n
+


### PR DESCRIPTION
## Summary
- localize Settings, Onboarding, and Home views via SwiftGen `L10n` enum
- add English and German entries for palette names and home title
- update SwiftGen config and helper script for regeneration

## Testing
- `scripts/generate_strings.sh` *(fails: swiftgen: command not found)*
- `swift test` *(fails: Invalid manifest: Product has no member 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6890676ab6ac8330b22e047949e2eb84