### PR TITLE
Centralize shared app configuration constants

### DIFF
--- a/OracleLightApp/Info.plist
+++ b/OracleLightApp/Info.plist
@@ -7,7 +7,7 @@
     <key>CFBundleName</key>
     <string>OracleLight</string>
     <key>CFBundleIdentifier</key>
-    <string>com.yourcompany.oraclelight</string>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
     <key>CFBundleVersion</key>
     <string>1</string>
     <key>CFBundleShortVersionString</key>

--- a/OracleLightApp/Services/DatabaseService.swift
+++ b/OracleLightApp/Services/DatabaseService.swift
@@ -1,5 +1,6 @@
 import Foundation
 import GRDB
+import OracleLightShared
 
 /// Responsible for initialising and providing access to the encrypted GRDB
 /// database. All database writes should occur on a background actor to avoid
@@ -22,12 +23,14 @@ final class DatabaseService {
     /// live activities, intents) can access the same data. The App Group
     /// identifier must also be declared in the targets' entitlements.
     private func databaseURL() throws -> URL {
-        // Use an App Group named "group.com.yourcompany.oraclelight". The
+        // Use an App Group named `AppConfig.appGroupIdentifier`. The
         // string must match the identifier configured in your Xcode project.
-        guard let containerURL = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: "group.com.yourcompany.oraclelight") else {
+        guard let containerURL = FileManager.default.containerURL(
+            forSecurityApplicationGroupIdentifier: AppConfig.appGroupIdentifier
+        ) else {
             throw NSError(domain: "DatabaseService", code: 1, userInfo: [NSLocalizedDescriptionKey: "App Group container not found"])
         }
-        return containerURL.appendingPathComponent("oracledb.sqlite")
+        return containerURL.appendingPathComponent(AppConfig.databaseFilename)
     }
 
     /// Initializes and migrates the encrypted database. Should be invoked once

--- a/OracleLightApp/Services/KeychainService.swift
+++ b/OracleLightApp/Services/KeychainService.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Security
+import OracleLightShared
 
 /// Provides a thin wrapper around the iOS Keychain for storing and retrieving
 /// the database encryption key. Keys are stored with
@@ -9,15 +10,15 @@ final class KeychainService {
     static let shared = KeychainService()
     private init() {}
 
-    private let service = "com.yourcompany.oraclelight.dbkey"
-    private let account = "oraclelight_encryption_key"
+    private let service = AppConfig.keychainService
+    private let account = AppConfig.keychainAccount
 
     /// Keychain access group. When both the app and its extensions specify the
     /// same keychain access group entitlement, items stored under this group
     /// become available to all targets. This allows the live activity
     /// extension to retrieve the same SQLCipher key as the main app. Ensure
     /// that this string matches the value configured in your entitlements.
-    private let accessGroup = "group.com.yourcompany.oraclelight"
+    private let accessGroup = AppConfig.keychainAccessGroup
 
     /// Retrieves an existing 256‑bit key from the keychain or generates and
     /// persists a new key if none exists. The returned key is used to

--- a/OracleLightApp/Services/PurchaseController.swift
+++ b/OracleLightApp/Services/PurchaseController.swift
@@ -1,5 +1,6 @@
 import Foundation
 import StoreKit
+import OracleLightShared
 
 /// Handles loading and purchasing the one‑time non‑consumable product used to
 /// unlock premium features. On initialisation it queries the App Store for
@@ -12,7 +13,7 @@ final class PurchaseController: ObservableObject {
 
     /// The identifier of the non‑consumable product. This must match the
     /// identifier configured in App Store Connect.
-    private let productID = "oraclelight.pro"
+    private let productID = AppConfig.proProductID
 
     init() {
         Task { await load() }

--- a/OracleLightApp/Views/Settings/SettingsView.swift
+++ b/OracleLightApp/Views/Settings/SettingsView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import StoreKit
+import OracleLightShared
 
 /// Displays user settings including prompt times, minimum interval, colour palette,
 /// and purchase options. Includes an export database button and legal
@@ -113,8 +114,8 @@ struct DBExportDocument: FileDocument {
     init() {
         // Read the database file from the shared App Group into memory. In a real
         // implementation you would compress and password‑protect the file.
-        let container = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: "group.com.yourcompany.oraclelight")
-        let dbURL = container?.appendingPathComponent("oracledb.sqlite")
+        let container = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: AppConfig.appGroupIdentifier)
+        let dbURL = container?.appendingPathComponent(AppConfig.databaseFilename)
         self.data = (try? Data(contentsOf: dbURL ?? URL(fileURLWithPath: "/dev/null"))) ?? Data()
     }
     init(configuration: ReadConfiguration) throws {

--- a/OracleLightShared/Configuration/AppConfig.swift
+++ b/OracleLightShared/Configuration/AppConfig.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+public enum AppConfig {
+    // MARK: - App Group
+    public static let appGroupIdentifier = "group.com.yourcompany.oraclelight"
+
+    // MARK: - Keychain
+    public static let keychainService = "com.yourcompany.oraclelight.dbkey"
+    public static let keychainAccount = "oraclelight_encryption_key"
+    public static let keychainAccessGroup = "group.com.yourcompany.oraclelight"
+
+    // MARK: - StoreKit
+    public static let proProductID = "oraclelight.pro"
+
+    // MARK: - Database
+    public static let databaseFilename = "oracledb.sqlite"
+
+    // MARK: - Fastlane/Contact
+    public static let contactEmail = "support@yourcompany.com"
+    public static let bundleIdentifier = "com.yourcompany.oraclelight"
+}

--- a/OracleLightShared/Services/DatabaseService.swift
+++ b/OracleLightShared/Services/DatabaseService.swift
@@ -20,10 +20,12 @@ final class DatabaseService {
     /// live activities, intents) can access the same data. The App Group
     /// identifier must also be declared in the targets' entitlements.
     private func databaseURL() throws -> URL {
-        guard let containerURL = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: "group.com.yourcompany.oraclelight") else {
+        guard let containerURL = FileManager.default.containerURL(
+            forSecurityApplicationGroupIdentifier: AppConfig.appGroupIdentifier
+        ) else {
             throw NSError(domain: "DatabaseService", code: 1, userInfo: [NSLocalizedDescriptionKey: "App Group container not found"])
         }
-        return containerURL.appendingPathComponent("oracledb.sqlite")
+        return containerURL.appendingPathComponent(AppConfig.databaseFilename)
     }
 
     /// Lazily ensures the database is opened. If `setup()` has not been called

--- a/OracleLightShared/Services/KeychainService.swift
+++ b/OracleLightShared/Services/KeychainService.swift
@@ -10,9 +10,9 @@ final class KeychainService {
     static let shared = KeychainService()
     private init() {}
 
-    private let service = "com.yourcompany.oraclelight.dbkey"
-    private let account = "oraclelight_encryption_key"
-    private let accessGroup = "group.com.yourcompany.oraclelight"
+    private let service = AppConfig.keychainService
+    private let account = AppConfig.keychainAccount
+    private let accessGroup = AppConfig.keychainAccessGroup
 
     /// Retrieves an existing 256‑bit key from the keychain or generates and
     /// persists a new key if none exists. The returned key is used to

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,5 +1,10 @@
 default_platform(:ios)
 
+app_config_path = File.expand_path("../OracleLightShared/Configuration/AppConfig.swift", __dir__)
+app_config = File.read(app_config_path)
+bundle_identifier = app_config[/bundleIdentifier\s*=\s*"([^"]+)"/, 1]
+contact_email = app_config[/contactEmail\s*=\s*"([^"]+)"/, 1]
+
 platform :ios do
   desc "Build and upload a beta build to TestFlight"
   lane :beta do
@@ -9,14 +14,14 @@ platform :ios do
       export_method: "app-store",
       export_options: {
         provisioningProfiles: {
-          "com.yourcompany.oraclelight" => "match AppStore com.yourcompany.oraclelight"
+          bundle_identifier => "match AppStore #{bundle_identifier}"
         }
       }
     )
     upload_to_testflight(
       skip_waiting_for_build_processing: true,
       beta_app_review_info: {
-        contact_email: "support@yourcompany.com",
+        contact_email: contact_email,
         contact_first_name: "Oracle",
         contact_last_name: "Light",
         contact_phone: "+1 555 123 4567",


### PR DESCRIPTION
## Summary
- Introduce `AppConfig` to hold shared identifiers for app group, keychain, StoreKit, database, contact, and bundle
- Replace hardcoded strings across database, keychain, settings export, purchases, and build scripts with `AppConfig`
- Reference bundle identifier via build setting and parse `AppConfig` in Fastlane

## Testing
- `swift build --target OracleLightApp` *(fails: type 'Product' has no member 'app')*
- `swift build --target OracleLightWidget` *(fails: type 'Product' has no member 'app')*


------
https://chatgpt.com/codex/tasks/task_e_68906aaf5a74833088ff1db7d345c2d4