### PR TITLE
Improve settings loading error handling

### DIFF
--- a/OracleLightApp/Views/Onboarding/OnboardingFlowView.swift
+++ b/OracleLightApp/Views/Onboarding/OnboardingFlowView.swift
@@ -9,6 +9,7 @@ struct OnboardingFlowView: View {
     @Binding var hasSeenOnboarding: Bool
     @State private var step: Step = .privacy
     @State private var settings: Settings = Settings.default
+    @EnvironmentObject var errorState: ErrorState
 
     enum Step {
         case privacy
@@ -33,9 +34,12 @@ struct OnboardingFlowView: View {
         }
         .onAppear {
             Task {
-                // Load existing settings from the database to prefill prompt times
-                let loaded = try? await DatabaseService.shared.fetchSettings()
-                settings = loaded ?? Settings.default
+                do {
+                    // Load existing settings from the database to prefill prompt times
+                    settings = try await DatabaseService.shared.fetchSettings()
+                } catch {
+                    await errorState.present(error: error)
+                }
             }
         }
     }

--- a/OracleLightApp/Views/Settings/SettingsView.swift
+++ b/OracleLightApp/Views/Settings/SettingsView.swift
@@ -72,8 +72,12 @@ struct SettingsView: View {
         }
         .onAppear {
             Task {
-                settings = (try? await DatabaseService.shared.fetchSettings()) ?? Settings.default
-                // The purchase controller loads its state automatically on init
+                do {
+                    settings = try await DatabaseService.shared.fetchSettings()
+                    // The purchase controller loads its state automatically on init
+                } catch {
+                    await errorState.present(error: error)
+                }
             }
         }
         .fileExporter(isPresented: $isPresentingExporter, document: DBExportDocument()) { _ in }


### PR DESCRIPTION
## Summary
- add `ErrorState` environment object to onboarding flow
- surface database loading failures for onboarding via `ErrorState`
- handle settings load failures in Settings view

## Testing
- `swift test` *(fails: type 'Product' has no member 'app')*


------
https://chatgpt.com/codex/tasks/task_e_689078a7d3988330bca1bf228528b2ec