### PR TITLE
feat: handle missing App Store product info gracefully

### DIFF
--- a/OracleLightApp/Views/Settings/SettingsView.swift
+++ b/OracleLightApp/Views/Settings/SettingsView.swift
@@ -55,12 +55,16 @@ struct SettingsView: View {
             Section(header: Text(L10n.settingsPurchaseSection)) {
                 if purchaseController.isPurchased {
                     Text(L10n.settingsPurchaseThanks)
-                } else {
+                } else if let product = purchaseController.product {
                     Button(action: {
                         Task { await purchaseController.purchase(errorHandler: errorState) }
                     }) {
-                        Text(L10n.settingsPurchasePrice(purchaseController.product?.displayPrice ?? "€7.99"))
+                        Text(L10n.settingsPurchasePrice(product.displayPrice))
                     }
+                } else {
+                    // Product information is not yet available.
+                    Text("Loading store information...")
+                        .foregroundColor(.secondary)
                 }
             }
         }


### PR DESCRIPTION
## Summary
- improve purchase section by removing fallback price and showing loading state when App Store data is unavailable

## Testing
- `swift test` *(fails: 'Package.swift:14:10: error: type 'Product' has no member 'app'`)*

------
https://chatgpt.com/codex/tasks/task_e_68907a2f419483308954d0fcae9921e1